### PR TITLE
Implement relu operator

### DIFF
--- a/electron/libelectron/electron/op-relu.hh
+++ b/electron/libelectron/electron/op-relu.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "upcycle/upcycle-api.hh"
+#include "electron/electron.hh"
+
+namespace electron::operators {
+
+class ReluOp : public Operator {
+private:
+    upcycle::WorkHandle handle;
+
+    void * g_args_blob;
+    void * l_argss_blob;
+
+public:
+    ReluOp(
+        const std::shared_ptr<Backend>& _backend,
+        Tensor& src1,
+        Tensor& dst);
+
+    virtual void exec();
+
+    virtual ~ReluOp() {
+        backend->free_workhandle(handle);
+    }
+};
+
+}

--- a/electron/libelectron/src/operators/add/add-dev.cc
+++ b/electron/libelectron/src/operators/add/add-dev.cc
@@ -18,10 +18,11 @@ KERNEL(add_i8, AddGArgs, AddLArgs) {
     char * src1 = ((char *)g_args->src1) + l_args->off;
     char * src2 = ((char *)g_args->src2) + l_args->off;
     char * dst = ((char *)g_args->dst) + l_args->off;
+    size_t left = l_args->len; // Bytes left for the instruction
 
-    SIMD_SET_MASK(VLEN_MAX_I8 - 1);
+    SIMD_SET_MASK((1 << VLEN_MAX_I8) - 1);
 
-    for (size_t left = l_args->len; left > VLEN_MAX_I8; left -= VLEN_MAX_I8) {
+    for (; left > VLEN_MAX_I8; left -= VLEN_MAX_I8) {
         VLD(src1, V0);
         VLD(src2, V1);
         VADD_I8(V2, V0, V1);
@@ -44,10 +45,11 @@ KERNEL(add_u8, AddGArgs, AddLArgs) {
     char * src1 = ((char *)g_args->src1) + l_args->off;
     char * src2 = ((char *)g_args->src2) + l_args->off;
     char * dst = ((char *)g_args->dst) + l_args->off;
+    size_t left = l_args->len; // bytes left for the instruction
 
-    SIMD_SET_MASK(VLEN_MAX_U8 - 1);
+    SIMD_SET_MASK((1 << VLEN_MAX_U8) - 1);
 
-    for (size_t left = l_args->len; left > VLEN_MAX_U8; left -= VLEN_MAX_U8) {
+    for (; left > VLEN_MAX_U8; left -= VLEN_MAX_U8) {
         VLD(src1, V0);
         VLD(src2, V1);
         VADD_U8(V2, V0, V1);

--- a/electron/libelectron/src/operators/relu/relu-dev.cc
+++ b/electron/libelectron/src/operators/relu/relu-dev.cc
@@ -1,0 +1,35 @@
+#include "upcycle/upcycle-intrin.hh"
+#include "operators/kernel.hh"
+#include "operators/relu/relu-dev.hh"
+
+using namespace electron::operators::device;
+
+PREFETCH(relu_i8, ReluGArgs, ReluLArgs) {
+    char * src1 = ((char *)g_args->src1) + l_args->off;
+    char * dst = ((char *)g_args->dst) + l_args->off;
+
+    PREFETCH1(src1, l_args->len);
+    PREFETCH1(dst, l_args->len);
+}
+
+KERNEL(relu_i8, ReluGArgs, ReluLArgs) {
+    char * src1 = ((char *)g_args->src1) + l_args->off;
+    char * dst = ((char *)g_args->dst) + l_args->off;
+    size_t left;
+
+    SIMD_SET_MASK((1 << VLEN_MAX_I8) - 1);
+
+    for (left = l_args->len; left > VLEN_MAX_I8; left -= VLEN_MAX_I8) {
+        VLD(src1, V0);
+        RELU_I8(V0);
+        VST(dst, V0);
+
+        src1 += VLEN_MAX_I8;
+        dst += VLEN_MAX_I8;
+    }
+    SIMD_SET_MASK((1 << left) - 1);
+
+    VLD(src1, V0);
+    RELU_I8(V0);
+    VST(dst, V0);
+}

--- a/electron/libelectron/src/operators/relu/relu-dev.hh
+++ b/electron/libelectron/src/operators/relu/relu-dev.hh
@@ -1,0 +1,16 @@
+#pragma once
+#include "operators/kernel.hh"
+
+namespace electron::operators::device {
+
+struct ReluGArgs {
+    void * src1;
+    void * dst;
+};
+
+struct ReluLArgs {
+    size_t off;
+    size_t len;
+};
+
+}

--- a/electron/libelectron/src/operators/relu/relu.cc
+++ b/electron/libelectron/src/operators/relu/relu.cc
@@ -1,0 +1,73 @@
+#include "electron/op-relu.hh"
+#include "operators/relu/relu-dev.hh"
+
+using namespace upcycle;
+
+
+namespace electron::operators {
+
+ReluOp::ReluOp(
+    const std::shared_ptr<Backend>& _backend,
+    Tensor& src1,
+    Tensor& dst) : Operator(_backend)
+{
+    const size_t num_tiles = backend->num_tiles();
+    GlobalWorkList gwl(num_tiles);
+
+    const DataType dtype = src1.get_dtype();
+    assert(dst.get_dtype() == dtype);
+
+    const size_t num_elems = src1.num_elem();
+    assert(dst.num_elem() == num_elems);
+
+    KernelFunc kern = nullptr;
+    KernelFunc prefetch = nullptr;
+    size_t vlen = vlen = backend->vbitwidth() / 8 / dtype_size(dtype);
+
+    switch (dtype) {
+    case DT_INT8:
+        kern = backend->getsym("relu_i8_simd");
+        prefetch = backend->getsym("relu_i8_prefetch");
+        break;
+
+    default:
+        assert(false);
+    }
+
+    assert(kern != nullptr);
+    assert(prefetch != nullptr);
+
+    const size_t blk_size = 64; // TODO: should be sized to L1
+    const size_t num_blks = (num_elems + blk_size - 1) / blk_size;
+
+    g_args_blob = backend->malloc(sizeof(device::ReluGArgs));
+    l_argss_blob = backend->malloc(num_blks * sizeof(device::ReluLArgs));
+
+    device::ReluGArgs * g_args = (device::ReluGArgs *)g_args_blob;
+    device::ReluLArgs * l_argss = (device::ReluLArgs *)l_argss_blob;
+
+    g_args->src1 = src1.get_dev_ptr();
+    g_args->dst = dst.get_dev_ptr();
+
+    size_t off = 0;
+
+    for (size_t i = 0; i < num_blks; i++) {
+        l_argss[i] = device::ReluLArgs {
+            .off = off, .len = std::min(blk_size, num_elems - off) };
+
+        gwl[i % num_tiles].push_back(upcycle::WorkItem {
+            prefetch, kern, g_args, &l_argss[i] });
+
+        off += blk_size;
+    }
+
+    backend->sync_device(g_args_blob);
+    backend->sync_device(l_argss_blob);
+    handle = backend->put_worklist(gwl);
+}
+
+void ReluOp::exec() {
+    backend->enqueue(handle);
+}
+
+}


### PR DESCRIPTION
Included a new operator ReluOp, as well as added test in electron-test. This assumes RELU_I8 does relu operation in-place on each int8 element (it would be better if there's documentation for ISA).

This PR doesn't include implementation in `electron-tf`. If that's necessary, I'll try implement it later.